### PR TITLE
fix build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 dist: xenial
 language: python
-python:
-  - "2.7"
 
 notifications:
   slack: gr-tekrsa:DjrPye5uqPWsHpV2uKE9Axfu


### PR DESCRIPTION
by removing python which means we are now defaulting to python 3